### PR TITLE
fix: Account for duplicate letters

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,26 +12,32 @@ const wordlePrompt = {
 };
 
 async function check(guess) {
-  let results = [];
-  // loop over each letter in the word
-  for (let i in guess) {
-    let attempt = { letter: guess[i], color: "bgGrey" };
+  let puzzleCopy = puzzle;
+  const colors = Array(guess.length).fill(chalk.white.bgGrey);
+  // loop through guess and mark green if fully correct
+  for (let i = 0; i < guess.length; i++) {
     // check if the letter at the specified index in the guess word exactly
     // matches the letter at the specified index in the puzzle
-    if (attempt.letter === puzzle[i]) {
-      process.stdout.write(chalk.white.bgGreen.bold(` ${guess[i]} \t`));
-      continue;
+    if (guess[i] === puzzleCopy[i]) {
+      colors[i] = chalk.white.bgGreen;
+      // remove letter from answer, so it's not scored again
+      puzzleCopy = puzzleCopy.replace(guess[i], " ");
     }
+  }
+  // loop through guess and mark yellow if partially correct
+  for (let i = 0; i < guess.length; i++) {
     // check if the letter at the specified index in the guess word is at least
     // contained in the puzzle at some other position
-    if (puzzle.includes(attempt.letter)) {
-      process.stdout.write(chalk.white.bgYellow.bold(` ${guess[i]} \t`));
-      continue;
+    if (guess[i] !== puzzleCopy[i] && puzzleCopy.includes(guess[i])) {
+      colors[i] = chalk.white.bgYellow;
+      // remove letter from answer, so it's not scored again
+      puzzleCopy = puzzleCopy.replace(guess[i], " ");
     }
-    // otherwise the letter doesn't exist at all in the puzzle
-    process.stdout.write(chalk.white.bgGrey.bold(` ${guess[i]} \t`));
   }
-  return results;
+  // loop over each letter and use its color to print it
+  for (let i = 0; i < guess.length; i++) {
+    process.stdout.write(colors[i].bold(` ${guess[i]} \t`));
+  }
 }
 
 async function play(tries) {


### PR DESCRIPTION
Previously, if the guess contains duplicate letters, letters in the wrong spot would appear yellow even if there is only 1 occurrence in the word.

### Example:

If the answer is `"THOSE"`, if a player were to guess the word `"GEESE"`, the algorithm above would produce the result:

!['GRAY', 'YELLOW', 'YELLOW', 'GREEN', 'GREEN'](https://dev-to-uploads.s3.amazonaws.com/uploads/articles/q7jyqngllovjhw1tr4jt.png)

This would imply that the correct answer has two E's in the wrong location and one E in the correct location (a total of three E's).

The result should, however, only show 1 E being in the word:

!['GRAY', 'GRAY', 'GRAY', 'GREEN', 'GREEN'](https://dev-to-uploads.s3.amazonaws.com/uploads/articles/q2hmn7w9chgso63tectj.png) 

### Another example:

If the answer is `"DREAD"`, and `"ADDED"` is guessed, the result produced would be:

!['YELLOW', 'YELLOW', 'YELLOW', 'YELLOW', 'GREEN'](https://dev-to-uploads.s3.amazonaws.com/uploads/articles/b8qnb698dwvt8ys7tc83.png) 

This implies no letters are missing, but in fact, one of the D's is wrong and the R is missing. Only *one* of the wrongly placed D's should be marked Yellow.

!['YELLOW', 'YELLOW', 'GRAY', 'YELLOW', 'GREEN'](https://dev-to-uploads.s3.amazonaws.com/uploads/articles/h7rwe7j9orb4u6azptpa.png) 

----

The change I've made to the code accounts for these duplicates and produces results similar to the original Wordle.